### PR TITLE
Refetch post after toggle disable patch

### DIFF
--- a/webapp/components/Modal/DisableModal.vue
+++ b/webapp/components/Modal/DisableModal.vue
@@ -69,9 +69,6 @@ export default {
         setTimeout(() => {
           this.$emit('close')
         }, 1000)
-        setTimeout(() => {
-          location.reload()
-        }, 250)
       } catch (err) {
         this.$toast.error(err.message)
       }

--- a/webapp/components/Modal/DisableModal.vue
+++ b/webapp/components/Modal/DisableModal.vue
@@ -65,6 +65,7 @@ export default {
         })
         this.$toast.success(this.$t('disable.success'))
         this.isOpen = false
+        this.$root.$emit('toggleDisable')
         setTimeout(() => {
           this.$emit('close')
         }, 1000)

--- a/webapp/components/PostCard/index.vue
+++ b/webapp/components/PostCard/index.vue
@@ -18,9 +18,7 @@
       </div>
       <ds-space margin-bottom="small" />
       <!-- Post Title -->
-      <ds-heading tag="h3" no-margin>
-        {{ post.title }}
-      </ds-heading>
+      <ds-heading tag="h3" no-margin>{{ post.title }}</ds-heading>
       <ds-space margin-bottom="small" />
       <!-- Post Content Excerpt -->
       <!-- eslint-disable vue/no-v-html -->

--- a/webapp/components/ReleaseModal/ReleaseModal.spec.js
+++ b/webapp/components/ReleaseModal/ReleaseModal.spec.js
@@ -28,10 +28,11 @@ describe('ReleaseModal.vue', () => {
       },
       $t: jest.fn(),
       $apollo: {
-        mutate: jest.fn()
-                    .mockResolvedValueOnce({ enable: 'u4711' })
-                    .mockRejectedValue({ message: 'Not Authorised!' })
-      },            
+        mutate: jest
+          .fn()
+          .mockResolvedValueOnce({ enable: 'u4711' })
+          .mockRejectedValue({ message: 'Not Authorised!' }),
+      },
     }
   })
 
@@ -144,7 +145,7 @@ describe('ReleaseModal.vue', () => {
           wrapper = Wrapper()
           wrapper.find('button.confirm').trigger('click')
         })
-        
+
         afterEach(() => {
           jest.clearAllMocks()
         })

--- a/webapp/components/ReleaseModal/ReleaseModal.spec.js
+++ b/webapp/components/ReleaseModal/ReleaseModal.spec.js
@@ -23,16 +23,15 @@ describe('ReleaseModal.vue', () => {
         truncate: a => a,
       },
       $toast: {
-        success: () => {},
-        error: () => {},
+        success: jest.fn(),
+        error: jest.fn(),
       },
       $t: jest.fn(),
       $apollo: {
-        mutate: jest.fn().mockResolvedValue(),
-      },
-      location: {
-        reload: jest.fn(),
-      },
+        mutate: jest.fn()
+                    .mockResolvedValueOnce({ enable: 'u4711' })
+                    .mockRejectedValue({ message: 'Not Authorised!' })
+      },            
     }
   })
 
@@ -145,6 +144,10 @@ describe('ReleaseModal.vue', () => {
           wrapper = Wrapper()
           wrapper.find('button.confirm').trigger('click')
         })
+        
+        afterEach(() => {
+          jest.clearAllMocks()
+        })
 
         it('calls mutation', () => {
           expect(mocks.$apollo.mutate).toHaveBeenCalled()
@@ -167,6 +170,18 @@ describe('ReleaseModal.vue', () => {
 
           it('emits close', () => {
             expect(wrapper.emitted().close).toBeTruthy()
+          })
+        })
+
+        describe('handles errors', () => {
+          beforeEach(() => {
+            wrapper = Wrapper()
+            // second submission causes mutation to reject
+            wrapper.find('button.confirm').trigger('click')
+          })
+
+          it('shows an error toaster when mutation rejects', async () => {
+            await expect(mocks.$toast.error).toHaveBeenCalledTimes(1)
           })
         })
       })

--- a/webapp/components/ReleaseModal/ReleaseModal.vue
+++ b/webapp/components/ReleaseModal/ReleaseModal.vue
@@ -55,19 +55,13 @@ export default {
           `,
           variables: { id: this.id },
         })
+
         this.$toast.success(this.$t('release.success'))
         this.isOpen = false
-        /*
-        setTimeout(() => {
-          location.reload()
-        }, 1500)
-        */
+        this.$root.$emit('toggleDisable')
         setTimeout(() => {
           this.$emit('close')
         }, 1000)
-        setTimeout(() => {
-          location.reload()
-        }, 250)
       } catch (err) {
         this.$toast.error(err.message)
       }

--- a/webapp/graphql/PostQuery.js
+++ b/webapp/graphql/PostQuery.js
@@ -1,0 +1,79 @@
+import gql from 'graphql-tag'
+
+export default app => {
+  const lang = app.$i18n.locale().toUpperCase()
+  return gql(`
+    query Post($slug: String!) {
+      Post(slug: $slug) {
+        id
+        title
+        content
+        createdAt
+        disabled
+        deleted
+        slug
+        image
+        author {
+          id
+          slug
+          name
+          avatar
+          disabled
+          deleted
+          shoutedCount
+          contributionsCount
+          commentsCount
+          followedByCount
+          followedByCurrentUser
+          location {
+            name: name${lang}
+          }
+          badges {
+            id
+            key
+            icon
+          }
+        }
+        tags {
+          name
+        }
+        commentsCount
+        comments(orderBy: createdAt_desc) {
+          id
+          contentExcerpt
+          createdAt
+          disabled
+          deleted
+          author {
+            id
+            slug
+            name
+            avatar
+            disabled
+            deleted
+            shoutedCount
+            contributionsCount
+            commentsCount
+            followedByCount
+            followedByCurrentUser
+            location {
+              name: name${lang}
+            }
+            badges {
+              id
+              key
+              icon
+            }
+          }
+        }
+        categories {
+          id
+          name
+          icon
+        }
+        shoutedCount
+        shoutedByCurrentUser
+      }
+    }
+  `)
+}

--- a/webapp/pages/post/_id/_slug/index.spec.js
+++ b/webapp/pages/post/_id/_slug/index.spec.js
@@ -41,6 +41,11 @@ describe('PostSlug', () => {
       },
       $apollo: {
         mutate: jest.fn().mockResolvedValue(),
+        queries: {
+          Post: {
+            refetch: jest.fn(),
+          },
+        },
       },
     }
   })
@@ -94,6 +99,14 @@ describe('PostSlug', () => {
             expect(mocks.$toast.success).toHaveBeenCalledTimes(1)
           })
         })
+      })
+    })
+
+    describe('toggleDisable', () => {
+      it('refetches Post when a toggleDisable event occurs', () => {
+        wrapper = Wrapper()
+        wrapper.vm.$root.$emit('toggleDisable')
+        expect(mocks.$apollo.queries.Post.refetch).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -17,9 +17,7 @@
         />
       </no-ssr>
       <ds-space margin-bottom="small" />
-      <ds-heading tag="h3" no-margin>
-        {{ post.title }}
-      </ds-heading>
+      <ds-heading tag="h3" no-margin>{{ post.title }}</ds-heading>
       <ds-space margin-bottom="small" />
       <!-- Content -->
       <!-- eslint-disable vue/no-v-html -->
@@ -205,6 +203,9 @@ export default {
     }
   },
   mounted() {
+    this.$root.$on('toggleDisable', () => {
+      this.toggleDisable()
+    })
     setTimeout(() => {
       // NOTE: quick fix for jumping flexbox implementation
       // will be fixed in a future update of the styleguide
@@ -212,8 +213,26 @@ export default {
     }, 50)
   },
   methods: {
+    toggleDisable() {
+      if (this.$apollo.queries.Post) {
+        this.$apollo.queries.Post.refetch()
+      }
+    },
     isAuthor(id) {
       return this.$store.getters['auth/user'].id === id
+    },
+  },
+  apollo: {
+    Post: {
+      query() {
+        return require('~/graphql/PostQuery.js').default(this)
+      },
+      variables() {
+        return {
+          slug: this.post.slug,
+        }
+      },
+      fetchPolicy: 'cache-and-network',
     },
   },
 }

--- a/webapp/pages/post/_id/_slug/more-info.vue
+++ b/webapp/pages/post/_id/_slug/more-info.vue
@@ -1,8 +1,6 @@
 <template>
   <ds-card>
-    <h2 style="margin-bottom: .2em;">
-      Mehr Informationen
-    </h2>
+    <h2 style="margin-bottom: .2em;">Mehr Informationen</h2>
     <p>Hier findest du weitere infos zum Thema.</p>
     <ds-space />
     <h3>


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-06-04T22:07:58Z" title="Wednesday, June 5th 2019, 12:07:58 am +02:00">Jun 5, 2019</time>_
_Closed <time datetime="2019-06-06T15:38:24Z" title="Thursday, June 6th 2019, 5:38:24 pm +02:00">Jun 6, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
This `PR` is a patch to get rid of `console.errors` in our tests and to avoid use of `location.reload` to reload the entire page, instead it emits an event, which refetches the post, since we are using `asyncData` for server-side rendering
