### PR TITLE
Fix deployment - wrong docker image name

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -2,7 +2,7 @@
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker build --build-arg BUILD_COMMIT=$TRAVIS_COMMIT --target production -t humanconnection/nitro-backend:latest $TRAVIS_BUILD_DIR/backend
 docker build --build-arg BUILD_COMMIT=$TRAVIS_COMMIT --target production -t humanconnection/nitro-web:latest $TRAVIS_BUILD_DIR/webapp
-docker build -t humanconnection/nitro-maintenance-worker:latest $TRAVIS_BUILD_DIR/deployment/legacy-migration/maintenance-worker
+docker build -t humanconnection/maintenance-worker:latest $TRAVIS_BUILD_DIR/deployment/legacy-migration/maintenance-worker
 docker push humanconnection/nitro-backend:latest
 docker push humanconnection/nitro-web:latest
-docker push humanconnection/nitro-maintenance-worker:latest
+docker push humanconnection/maintenance-worker:latest


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-05T08:35:28Z" title="Wednesday, June 5th 2019, 10:35:28 am +02:00">Jun 5, 2019</time>_
_Merged <time datetime="2019-06-05T11:37:34Z" title="Wednesday, June 5th 2019, 1:37:34 pm +02:00">Jun 5, 2019</time>_
---

## 🍰 Pullrequest
I made two mistakes:
1. Forgot to set permissions on dockerhub (done earlier)
2. Fix the name of the docker image in the deployment script

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
