### PR TITLE
Fix #800

### DIFF
--- a/backend/src/middleware/fixImageUrlsMiddleware.js
+++ b/backend/src/middleware/fixImageUrlsMiddleware.js
@@ -6,8 +6,11 @@ const legacyUrls = [
 
 export const fixUrl = url => {
   legacyUrls.forEach(legacyUrl => {
-    url = url.replace(legacyUrl, '/')
+    url = url.replace(legacyUrl, '')
   })
+  if (!url.startsWith('/')) {
+    url = `/${url}`
+  }
   return url
 }
 

--- a/backend/src/middleware/fixImageUrlsMiddleware.js
+++ b/backend/src/middleware/fixImageUrlsMiddleware.js
@@ -6,7 +6,7 @@ const legacyUrls = [
 
 export const fixUrl = url => {
   legacyUrls.forEach(legacyUrl => {
-    url = url.replace(legacyUrl, '/api')
+    url = url.replace(legacyUrl, '/')
   })
   return url
 }

--- a/backend/src/middleware/fixImageUrlsMiddleware.spec.js
+++ b/backend/src/middleware/fixImageUrlsMiddleware.spec.js
@@ -1,12 +1,19 @@
 import { fixImageURLs } from './fixImageUrlsMiddleware'
 
 describe('fixImageURLs', () => {
+  describe('edge case: image url is exact match of legacy url', () => {
+    it('replaces it with `/`', () => {
+      const url = 'https://api-alpha.human-connection.org'
+      expect(fixImageURLs(url)).toEqual('/')
+    })
+  })
+
   describe('image url of legacy alpha', () => {
     it('removes domain', () => {
       const url =
         'https://api-alpha.human-connection.org/uploads/4bfaf9172c4ba03d7645108bbbd16f0a696a37d01eacd025fb131e5da61b15d9.png'
       expect(fixImageURLs(url)).toEqual(
-        '/api/uploads/4bfaf9172c4ba03d7645108bbbd16f0a696a37d01eacd025fb131e5da61b15d9.png',
+        '/uploads/4bfaf9172c4ba03d7645108bbbd16f0a696a37d01eacd025fb131e5da61b15d9.png',
       )
     })
   })
@@ -16,7 +23,7 @@ describe('fixImageURLs', () => {
       const url =
         'https://staging-api.human-connection.org/uploads/1b3c39a24f27e2fb62b69074b2f71363b63b263f0c4574047d279967124c026e.jpeg'
       expect(fixImageURLs(url)).toEqual(
-        '/api/uploads/1b3c39a24f27e2fb62b69074b2f71363b63b263f0c4574047d279967124c026e.jpeg',
+        '/uploads/1b3c39a24f27e2fb62b69074b2f71363b63b263f0c4574047d279967124c026e.jpeg',
       )
     })
   })


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-12T21:27:57Z" title="Wednesday, June 12th 2019, 11:27:57 pm +02:00">Jun 12, 2019</time>_
_Merged <time datetime="2019-06-12T22:53:19Z" title="Thursday, June 13th 2019, 12:53:19 am +02:00">Jun 13, 2019</time>_
---


## 🍰 Pullrequest
Ok, so apparently all we have to do is to remove the `/api` prefix from
fixImageUrlMiddleware. I guess that's just a leftover.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #800 

