### PR TITLE
Page size of 12 entries on / page

### DIFF
--- a/webapp/pages/index.vue
+++ b/webapp/pages/index.vue
@@ -45,7 +45,7 @@ export default {
       // Initialize your apollo data
       Post: [],
       page: 1,
-      pageSize: 10,
+      pageSize: 12,
       filter: {},
     }
   },


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-06-22T07:09:27Z" title="Saturday, June 22nd 2019, 9:09:27 am +02:00">Jun 22, 2019</time>_
_Merged <time datetime="2019-06-25T09:50:24Z" title="Tuesday, June 25th 2019, 11:50:24 am +02:00">Jun 25, 2019</time>_
---

It annoys me that there are gaps for the 3 column layout, even if there
are more records left. So, the newsfeed layout has 1 column on mobile, 2
columns on tablet, and 3 columns on a desktop pc. So we should choose a
page size which is dividable by 1,2 and 3 that is 6. I have chosen 12
which is 2*6 to avoid clicking the reload posts button so often.

![Screenshot - 2019-06-22T090929 363](https://user-images.githubusercontent.com/2110676/59960768-60844b00-94cd-11e9-92ed-0e060eb80fb8.png)


## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
