### PR TITLE
Add basic styling for comment list

### DIFF
--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -1,30 +1,38 @@
 <template>
-  <div v-if="(comment.deleted || comment.disabled) && !isModerator">
-    <ds-text style="padding-left: 40px; font-weight: bold;" color="soft">
-      <ds-icon name="ban" />
-      {{ this.$t('comment.content.unavailable-placeholder') }}
-    </ds-text>
+  <div v-if="(comment.deleted || comment.disabled) && !isModerator" :class="{ comment: true }">
+    <ds-card>
+      <ds-space margin-bottom="base" />
+      <ds-text style="padding-left: 40px; font-weight: bold;" color="soft">
+        <ds-icon name="ban" />
+        {{ this.$t('comment.content.unavailable-placeholder') }}
+      </ds-text>
+      <ds-space margin-bottom="base" />
+    </ds-card>
   </div>
   <div v-else :class="{ comment: true, 'disabled-content': comment.deleted || comment.disabled }">
-    <ds-space margin-bottom="x-small">
-      <hc-user :user="author" :date-time="comment.createdAt" />
-    </ds-space>
-    <!-- Content Menu (can open Modals) -->
-    <no-ssr>
-      <content-menu
-        placement="bottom-end"
-        resource-type="comment"
-        :resource="comment"
-        :modalsData="menuModalsData"
-        style="float-right"
-        :is-owner="isAuthor(author.id)"
-      />
-    </no-ssr>
-    <!-- eslint-disable vue/no-v-html -->
-    <!-- TODO: replace editor content with tiptap render view -->
-    <ds-space margin-bottom="small" />
-    <div style="padding-left: 40px;" v-html="comment.contentExcerpt" />
-    <!-- eslint-enable vue/no-v-html -->
+    <ds-card>
+      <ds-space margin-bottom="small" />
+      <ds-space margin-bottom="small">
+        <hc-user :user="author" :date-time="comment.createdAt" />
+      </ds-space>
+      <!-- Content Menu (can open Modals) -->
+      <no-ssr>
+        <content-menu
+          placement="bottom-end"
+          resource-type="comment"
+          :resource="comment"
+          :modalsData="menuModalsData"
+          style="float-right"
+          :is-owner="isAuthor(author.id)"
+        />
+      </no-ssr>
+      <!-- eslint-disable vue/no-v-html -->
+      <!-- TODO: replace editor content with tiptap render view -->
+      <ds-space margin-bottom="small" />
+      <div style="padding-left: 40px;" v-html="comment.contentExcerpt" />
+      <!-- eslint-enable vue/no-v-html -->
+      <ds-space margin-bottom="x-small" />
+    </ds-card>
   </div>
 </template>
 


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-07-02T22:17:31Z" title="Wednesday, July 3rd 2019, 12:17:31 am +02:00">Jul 3, 2019</time>_
_Merged <time datetime="2019-07-02T22:48:50Z" title="Wednesday, July 3rd 2019, 12:48:50 am +02:00">Jul 3, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #717 
![Screenshot at 2019-07-02 19:04:01](https://user-images.githubusercontent.com/26943915/60550262-cb1f5d00-9cfd-11e9-99cb-794d15e38133.png)

with deleted comments, they aren't the same height, but I can add `margin-bottom="large"` to the `<ds-space />`, but since there is just a single line, not sure if it looks better or not
![Screenshot at 2019-07-02 19:13:36](https://user-images.githubusercontent.com/26943915/60550267-cf4b7a80-9cfd-11e9-89e2-6d3bd3e3914a.png)
