### PR TITLE
Neo4j uses a different name for its env vars

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,5 +1,5 @@
 NEO4J_URI=bolt://localhost:7687
-NEO4J_USER=neo4j
+NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=letmein
 GRAPHQL_PORT=4000
 GRAPHQL_URI=http://localhost:4000

--- a/deployment/human-connection/deployment-neo4j.yaml
+++ b/deployment/human-connection/deployment-neo4j.yaml
@@ -32,21 +32,9 @@
             value: 1G
           - name: NEO4J_dbms_memory_heap_max__size
             value: 1G
-          - name: NEO4J_URI
-            valueFrom:
-              configMapKeyRef:
-                name: configmap
-                key: NEO4J_URI
-          - name: NEO4J_USER
-            valueFrom:
-              configMapKeyRef:
-                name: configmap
-                key: NEO4J_USER
-          - name: NEO4J_AUTH
-            valueFrom:
-              configMapKeyRef:
-                name: configmap
-                key: NEO4J_AUTH
+          envFrom:
+          - configMapRef:
+              name: configmap
           ports:
           - containerPort: 7687
           - containerPort: 7474

--- a/deployment/human-connection/templates/configmap.template.yaml
+++ b/deployment/human-connection/templates/configmap.template.yaml
@@ -10,7 +10,8 @@
     GRAPHQL_URI: "http://nitro-backend.human-connection:4000"
     MOCKS: "false"
     NEO4J_URI: "bolt://nitro-neo4j.human-connection:7687"
-    NEO4J_USER: "neo4j"
+    NEO4J_USERNAME: "neo4j"
+    NEO4J_PASSWORD: "neo4j"
     NEO4J_AUTH: "none"
     CLIENT_URI: "https://nitro-staging.human-connection.org"
   metadata:


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-07-05T13:52:24Z" title="Friday, July 5th 2019, 3:52:24 pm +02:00">Jul 5, 2019</time>_
_Merged <time datetime="2019-07-09T13:21:23Z" title="Tuesday, July 9th 2019, 3:21:23 pm +02:00">Jul 9, 2019</time>_
---

## 🍰 Pullrequest
Neo4j is looking for `NEO4J_USERNAME` and `NEO4J_PASSWORD` but not for `NEO4J_USER`.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
