### PR TITLE
Use hyphens to separate words properly

### DIFF
--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -164,3 +164,9 @@ hr {
 .v-popover.open .trigger a {
   color: $text-color-link-active;
 }
+
+.hyphenate-text {
+  hyphens: auto;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}

--- a/webapp/components/PostCard/index.vue
+++ b/webapp/components/PostCard/index.vue
@@ -20,12 +20,12 @@
     </div>
     <ds-space margin-bottom="small" />
     <!-- Post Title -->
-    <ds-heading tag="h3" no-margin>{{ post.title }}</ds-heading>
+    <ds-heading tag="h3" no-margin class="hyphenate-text">{{ post.title }}</ds-heading>
     <ds-space margin-bottom="small" />
     <!-- Post Content Excerpt -->
     <!-- eslint-disable vue/no-v-html -->
     <!-- TODO: replace editor content with tiptap render view -->
-    <div class="hc-editor-content" v-html="excerpt" />
+    <div class="hc-editor-content hyphenate-text" v-html="excerpt" />
     <!-- eslint-enable vue/no-v-html -->
     <!-- Footer o the Post -->
     <template slot="footer">

--- a/webapp/layouts/default.vue
+++ b/webapp/layouts/default.vue
@@ -121,7 +121,7 @@
         </div>
       </ds-container>
     </div>
-    <ds-container style="word-break: break-all">
+    <ds-container>
       <div class="main-container">
         <nuxt />
       </div>

--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -18,9 +18,9 @@
         />
       </client-only>
       <ds-space margin-bottom="small" />
-      <ds-heading tag="h3" no-margin>{{ post.title }}</ds-heading>
+      <ds-heading tag="h3" no-margin class="hyphenate-text">{{ post.title }}</ds-heading>
       <ds-space margin-bottom="small" />
-      <content-viewer class="content" :content="post.content" />
+      <content-viewer class="content hyphenate-text" :content="post.content" />
       <!-- eslint-enable vue/no-v-html -->
       <ds-space margin="xx-large" />
       <!-- Categories -->

--- a/webapp/pages/profile/_id/_slug.vue
+++ b/webapp/pages/profile/_id/_slug.vue
@@ -72,7 +72,7 @@
           <template v-if="user.about">
             <hr />
             <ds-space margin-top="small" margin-bottom="small">
-              <ds-text color="soft" size="small">{{ user.about }}</ds-text>
+              <ds-text color="soft" size="small" class="hyphenate-text">{{ user.about }}</ds-text>
             </ds-space>
           </template>
         </ds-card>


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2019-09-02T16:03:33Z" title="Monday, September 2nd 2019, 6:03:33 pm +02:00">Sep 2, 2019</time>_
_Merged <time datetime="2019-09-03T16:12:03Z" title="Tuesday, September 3rd 2019, 6:12:03 pm +02:00">Sep 3, 2019</time>_
---

## 🍰 Pullrequest
Uses hyphenation for
- [x] post titles
- [x] post content
- [x] user description
- [ ] am I missing something?

This solution does not work for all languages in all browsers on all operating systems (it's complicated :smirk:) – as a fallback words will still break in random places when they would otherwise overflow.

Setting hyphens to `auto` also means that _all_ words can potentially break, not just the very long ones overflowing the container. Unfortunately at this point this is a binary setting in CSS (can be either `on` or `off`) but there is a [property in planning](https://drafts.csswg.org/css-text-4/#hyphenate-char-limits) that would allow us to set a hyphenation threshold. I hope this will be implemented soon! Until then...

### Issues
- fixes #1219 
