### PR TITLE
Speed up builds, `docker-compose build --parallel`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
   - cp cypress.env.template.json cypress.env.json
 
 install:
-  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up --build -d
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml build --parallel
+  - docker-compose -f docker-compose.yml -f docker-compose.travis.yml up -d
     # avoid "Database constraints have changed after this transaction started"
   - wait-on http://localhost:7474
   - docker-compose exec neo4j db_setup


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-09-11T11:08:06Z" title="Wednesday, September 11th 2019, 1:08:06 pm +02:00">Sep 11, 2019</time>_
_Closed <time datetime="2019-09-12T11:05:20Z" title="Thursday, September 12th 2019, 1:05:20 pm +02:00">Sep 12, 2019</time>_
---

Found this: https://devops.stackexchange.com/questions/1343/is-it-possible-to-build-docker-images-using-docker-compose-concurrently

Tought: Let's try out immediately

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
