### PR TITLE
Fix styling issue in comments list

### DIFF
--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -16,7 +16,7 @@
       </span>
     </h3>
     <ds-space margin-bottom="large" />
-    <div v-if="post.comments && post.comments.length" id="comments">
+    <div v-if="post.comments && post.comments.length" id="comments" class="comments">
       <comment
         v-for="comment in post.comments"
         :key="comment.id"


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-09-19T14:00:40Z" title="Thursday, September 19th 2019, 4:00:40 pm +02:00">Sep 19, 2019</time>_
_Merged <time datetime="2019-09-19T14:35:24Z" title="Thursday, September 19th 2019, 4:35:24 pm +02:00">Sep 19, 2019</time>_
---

- add back class comments which adds spaces between comments

![Screenshot from 2019-09-19 16-00-29](https://user-images.githubusercontent.com/26943915/65250896-9ea60080-daf6-11e9-8e9b-9fc1d99c2c1b.png)
