### PR TITLE
Remove sleep icon from comments list

### DIFF
--- a/webapp/components/CommentList/CommentList.spec.js
+++ b/webapp/components/CommentList/CommentList.spec.js
@@ -1,6 +1,5 @@
 import { config, mount, createLocalVue } from '@vue/test-utils'
 import CommentList from './CommentList'
-import Empty from '~/components/Empty'
 import Vuex from 'vuex'
 import Styleguide from '@human-connection/styleguide'
 import Filters from '~/plugins/vue-filters'
@@ -68,11 +67,6 @@ describe('CommentList.vue', () => {
 
     beforeEach(() => {
       wrapper = Wrapper()
-    })
-
-    it('displays a message icon when there are no comments to display', () => {
-      propsData.post.comments = []
-      expect(Wrapper().findAll(Empty)).toHaveLength(1)
     })
 
     it('displays a comments counter', () => {

--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -26,17 +26,14 @@
         @updateComment="updateCommentList"
       />
     </div>
-    <hc-empty v-else name="empty" icon="messages" />
   </div>
 </template>
 <script>
 import Comment from '~/components/Comment.vue'
-import HcEmpty from '~/components/Empty.vue'
 
 export default {
   components: {
     Comment,
-    HcEmpty,
   },
   props: {
     post: { type: Object, default: () => {} },

--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -12,7 +12,7 @@
         >
           {{ post.comments.length }}
         </ds-tag>
-        &nbsp; Comments
+        <span class="list-title">{{ $t('common.comment', null, 0) }}</span>
       </span>
     </h3>
     <ds-space margin-bottom="large" />
@@ -47,3 +47,9 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" scoped>
+.list-title {
+  margin-left: $space-x-small;
+}
+</style>


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2019-09-23T20:13:04Z" title="Monday, September 23rd 2019, 10:13:04 pm +02:00">Sep 23, 2019</time>_
_Merged <time datetime="2019-09-24T08:59:30Z" title="Tuesday, September 24th 2019, 10:59:30 am +02:00">Sep 24, 2019</time>_
---

## 🍰 Pullrequest
- removes the sleep icon from the empty comments list
- uses `comments` from the translation files as title

### Issues
- fixes #1659 
