### PR TITLE
🍰 Try to fix VSCode format works against ESLint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
       "autoFix": true
     }
   ],
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "eslint.autoFixOnSave": true
 }


### PR DESCRIPTION
> [<img alt="Tirokk" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Tirokk) **Authored by [Tirokk](https://github.com/Tirokk)**
_<time datetime="2019-09-27T15:19:57Z" title="Friday, September 27th 2019, 5:19:57 pm +02:00">Sep 27, 2019</time>_
_Merged <time datetime="2019-09-28T13:34:01Z" title="Saturday, September 28th 2019, 3:34:01 pm +02:00">Sep 28, 2019</time>_
---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

VSCode `editor.formatOnSave` seems sometimes to works against ESLint `eslint.autoFixOnSave`.

Please try out in your VSCode.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
