### PR TITLE
docs: moves storybook into webapp/README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,41 +90,6 @@ $ yarn run db:reset
 {% endtab %}
 {% endtabs %}
 
-### Storybook
-
-We encourage contributors to use Storybook to test out new components in an isolated way, and benefit from its many features.
-See the docs for live examples and answers to FAQ, among other helpful information. ![Storybook docs](https://storybook.js.org/docs/basics/introduction/)
-
-{% tabs %}
-{% tab title="Docker" %}
-
-After you have started the application following the instructions above, in another terminal run:
-
-```bash
-$ docker-compose exec webapp yarn storybook
-```
-The output should look similar to this:
-
-![Storybook output](../.gitbook/assets/storybook-output.png)
-
-Click on the link http://localhost:3002/ to open the browser to your interactive storybook.
-
-{% endtab %}
-
-{% tab title="Without Docker" %}
-Run the following command: 
-
-```bash
-# in webapp/
-yarn storybook
-```
-
-Open http://localhost:3002/ in your browser
-
-{% endtab %}
-{% endtabs %}
-
-
 # Testing
 
 **Beware**: We have no multiple database setup at the moment. We clean the

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -33,6 +33,42 @@ $ yarn build
 $ yarn start
 ```
 
+### Storybook
+
+We encourage contributors to use Storybook to test out new components in an isolated way, and benefit from its many features.
+See the docs for live examples and answers to FAQ, among other helpful information. ![Storybook docs](https://storybook.js.org/docs/basics/introduction/)
+
+{% tabs %}
+{% tab title="Docker" %}
+
+After you have started the application following the instructions above, in another terminal run:
+
+```bash
+$ docker-compose exec webapp yarn storybook
+```
+The output should look similar to this:
+
+![Storybook output](../.gitbook/assets/storybook-output.png)
+
+Click on the link http://localhost:3002/ to open the browser to your interactive storybook.
+
+{% endtab %}
+
+{% tab title="Without Docker" %}
+Run the following command:
+
+```bash
+# in webapp/
+yarn storybook
+```
+
+Open http://localhost:3002/ in your browser
+
+{% endtab %}
+{% endtabs %}
+
+
+
 ## Styleguide
 
 All reusable Components \(for example avatar\) should be done inside the [Nitro-Styleguide](https://github.com/Human-Connection/Nitro-Styleguide) repository.


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-09-28T22:14:13Z" title="Sunday, September 29th 2019, 12:14:13 am +02:00">Sep 29, 2019</time>_
_Merged <time datetime="2019-09-29T21:01:03Z" title="Sunday, September 29th 2019, 11:01:03 pm +02:00">Sep 29, 2019</time>_
---

It makes much more sense to put it under the webapp's README than backend.

FYI: @mattwr18

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
