### PR TITLE
Max aspect ratio of 1:1 for Post index page

### DIFF
--- a/webapp/pages/post/_id/_slug/index.vue
+++ b/webapp/pages/post/_id/_slug/index.vue
@@ -197,7 +197,7 @@ export default {
 
     .ds-card-image {
       img {
-        height: 300px;
+        max-height: 710px;
         object-fit: cover;
         object-position: center;
       }


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2019-10-02T15:00:31Z" title="Wednesday, October 2nd 2019, 5:00:31 pm +02:00">Oct 2, 2019</time>_
_Merged <time datetime="2019-10-04T12:00:12Z" title="Friday, October 4th 2019, 2:00:12 pm +02:00">Oct 4, 2019</time>_
---

- we are currently enforcing a 1:1 max ratio on the root path and would
like to maintain consistency


