### PR TITLE
overflow: hidden on body removed when popover

### DIFF
--- a/webapp/assets/styles/main.scss
+++ b/webapp/assets/styles/main.scss
@@ -52,7 +52,6 @@ $easeOut: cubic-bezier(0.19, 1, 0.22, 1);
 
 body.dropdown-open {
   height: 100vh;
-  overflow: hidden;
 }
 
 blockquote {


### PR DESCRIPTION
> [<img alt="leternoz" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/leternoz) **Authored by [leternoz](https://github.com/leternoz)**
_<time datetime="2019-10-27T23:11:34Z" title="Monday, October 28th 2019, 12:11:34 am +01:00">Oct 28, 2019</time>_
_Closed <time datetime="2019-12-06T12:52:56Z" title="Friday, December 6th 2019, 1:52:56 pm +01:00">Dec 6, 2019</time>_
---

## 🍰 Pullrequest

The CSS property `overflow: hidden` was set on the `body` when the pointer hover the avatar. I don't know if this was done on purpose, but by removing it, now it doesn't hide the scrollbar.

![Screenshot_20191028_000643](https://user-images.githubusercontent.com/29784958/67643363-eea68d00-f916-11e9-85e9-c031d37b6dfc.png)


### Issues
- fixes #1857

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
