### PR TITLE
1931 - after successful login the saved language of the user is set

### DIFF
--- a/webapp/pages/login.vue
+++ b/webapp/pages/login.vue
@@ -26,7 +26,7 @@ export default {
   },
   methods: {
     handleSuccess() {
-      this.$i18n.set(this.user.locale)
+      this.$i18n.set(this.user.locale || 'en')
       this.$router.replace(this.$route.query.path || '/')
     },
   },

--- a/webapp/pages/login.vue
+++ b/webapp/pages/login.vue
@@ -25,8 +25,8 @@ export default {
     }
   },
   methods: {
-    handleSuccess() {      
-      this.$i18n.set(this.user.locale)   
+    handleSuccess() {
+      this.$i18n.set(this.user.locale)
       this.$router.replace(this.$route.query.path || '/')
     },
   },

--- a/webapp/pages/login.vue
+++ b/webapp/pages/login.vue
@@ -25,12 +25,8 @@ export default {
     }
   },
   methods: {
-    handleSuccess() {
-      const currentLocale = this.$i18n.locale()
-      const userSettingLocale = this.user.locale
-      if (currentLocale !== userSettingLocale) {
-        this.$i18n.set(userSettingLocale)
-      }
+    handleSuccess() {      
+      this.$i18n.set(this.user.locale)   
       this.$router.replace(this.$route.query.path || '/')
     },
   },

--- a/webapp/pages/login.vue
+++ b/webapp/pages/login.vue
@@ -7,11 +7,17 @@
 <script>
 import LoginForm from '~/components/LoginForm/LoginForm.vue'
 import { VERSION } from '~/constants/terms-and-conditions-version.js'
+import { mapGetters } from 'vuex'
 
 export default {
   layout: 'no-header',
   components: {
     LoginForm,
+  },
+  computed: {
+    ...mapGetters({
+      user: 'auth/user',
+    }),
   },
   asyncData({ store, redirect }) {
     if (store.getters['auth/user'].termsAndConditionsAgreedVersion === VERSION) {
@@ -20,6 +26,11 @@ export default {
   },
   methods: {
     handleSuccess() {
+      const currentLocale = this.$i18n.locale()
+      const userSettingLocale = this.user.locale
+      if (currentLocale !== userSettingLocale) {
+        this.$i18n.set(userSettingLocale)
+      }
       this.$router.replace(this.$route.query.path || '/')
     },
   },

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -46,6 +46,9 @@ export const getters = {
   termsAndConditionsAgreed(state) {
     return state.user && state.user.termsAndConditionsAgreedVersion === VERSION
   },
+  locale(state) {
+    return state.locale
+  },
 }
 
 export const actions = {
@@ -84,6 +87,7 @@ export const actions = {
             role
             about
             locationName
+            locale
             contributionsCount
             commentedCount
             allowEmbedIframes

--- a/webapp/store/auth.js
+++ b/webapp/store/auth.js
@@ -46,9 +46,6 @@ export const getters = {
   termsAndConditionsAgreed(state) {
     return state.user && state.user.termsAndConditionsAgreedVersion === VERSION
   },
-  locale(state) {
-    return state.locale
-  },
 }
 
 export const actions = {

--- a/webapp/store/auth.test.js
+++ b/webapp/store/auth.test.js
@@ -13,6 +13,7 @@ const currentUser = {
   email: 'user@example.org',
   avatar: 'https://s3.amazonaws.com/uifaces/faces/twitter/mutu_krish/128.jpg',
   role: 'user',
+  locale: 'de',
 }
 const successfulLoginResponse = { data: { login: token } }
 const successfulCurrentUserResponse = { data: { currentUser } }
@@ -126,6 +127,7 @@ describe('actions', () => {
                 email: 'user@example.org',
                 avatar: 'https://s3.amazonaws.com/uifaces/faces/twitter/mutu_krish/128.jpg',
                 role: 'user',
+                locale: 'de',
               },
             ],
           ]),


### PR DESCRIPTION
> [<img alt="ogerly" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/ogerly) **Authored by [ogerly](https://github.com/ogerly)**
_<time datetime="2019-10-29T10:09:42Z" title="Tuesday, October 29th 2019, 11:09:42 am +01:00">Oct 29, 2019</time>_
_Merged <time datetime="2019-11-11T10:43:12Z" title="Monday, November 11th 2019, 11:43:12 am +01:00">Nov 11, 2019</time>_
---

## 🍰 Pullrequest
after successful login the saved language of the user is set

### Issues GROUP
- fixes #1931
  