### PR TITLE
fix(editor): Fix embed thumbnail height

### DIFF
--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -377,6 +377,7 @@ li > p {
 .embed-preview-image {
   width: 100%;
   height: auto;
+  max-height: 450px;
 }
 
 .embed-preview-image--clickable {


### PR DESCRIPTION
> [<img alt="MarcoBomfim" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/MarcoBomfim) **Authored by [MarcoBomfim](https://github.com/MarcoBomfim)**
_<time datetime="2019-11-06T19:50:26Z" title="Wednesday, November 6th 2019, 8:50:26 pm +01:00">Nov 6, 2019</time>_
_Closed <time datetime="2019-11-14T19:15:18Z" title="Thursday, November 14th 2019, 8:15:18 pm +01:00">Nov 14, 2019</time>_
---

## 🍰 Pullrequest
Simple PR to add max-height for thumbnail images, so we can avoid what happened in the bug report below.

### Issues
- fixes #1936 