### PR TITLE
fix: return `null` for missig translations

### DIFF
--- a/backend/src/schema/resolvers/locations.js
+++ b/backend/src/schema/resolvers/locations.js
@@ -1,0 +1,19 @@
+import Resolver from './helpers/Resolver'
+
+export default {
+  Location: {
+    ...Resolver('Location', {
+      undefinedToNull: [
+        'nameEN',
+        'nameDE',
+        'nameFR',
+        'nameNL',
+        'nameIT',
+        'nameES',
+        'namePT',
+        'namePL',
+        'nameRU',
+      ],
+    }),
+  },
+}

--- a/backend/src/schema/resolvers/locations.spec.js
+++ b/backend/src/schema/resolvers/locations.spec.js
@@ -6,8 +6,7 @@ import { createTestClient } from 'apollo-server-testing'
 
 const factory = Factory()
 
-let mutate
-let authenticatedUser
+let mutate, authenticatedUser
 
 const driver = getDriver()
 const neode = getNeode()

--- a/backend/src/schema/resolvers/locations.spec.js
+++ b/backend/src/schema/resolvers/locations.spec.js
@@ -1,0 +1,86 @@
+import Factory from '../../seed/factories'
+import { gql } from '../../jest/helpers'
+import { neode as getNeode, getDriver } from '../../bootstrap/neo4j'
+import createServer from '../../server'
+import { createTestClient } from 'apollo-server-testing'
+
+const factory = Factory()
+
+let mutate
+let authenticatedUser
+
+const driver = getDriver()
+const neode = getNeode()
+
+beforeAll(() => {
+  const { server } = createServer({
+    context: () => {
+      return {
+        driver,
+        neode,
+        user: authenticatedUser,
+      }
+    },
+  })
+  mutate = createTestClient(server).mutate
+})
+
+afterEach(async () => {
+  await factory.cleanDatabase()
+})
+
+describe('resolvers', () => {
+  describe('Location', () => {
+    describe('custom mutation, not handled by neo4j-graphql-js', () => {
+      let variables
+      const updateUserMutation = gql`
+        mutation($id: ID!, $name: String) {
+          UpdateUser(id: $id, name: $name) {
+            name
+            location {
+              name: nameRU
+              nameEN
+            }
+          }
+        }
+      `
+
+      beforeEach(async () => {
+        variables = {
+          id: 'u47',
+          name: 'John Doughnut',
+        }
+        const Paris = await factory.create('Location', {
+          id: 'region.9397217726497330',
+          name: 'Paris',
+          type: 'region',
+          lat: 2.35183,
+          lng: 48.85658,
+          nameEN: 'Paris',
+        })
+
+        const user = await factory.create('User', {
+          id: 'u47',
+          name: 'John Doe',
+        })
+        await user.relateTo(Paris, 'isIn')
+        authenticatedUser = await user.toJson()
+      })
+
+      it('returns `null` if location translation is not available', async () => {
+        await expect(mutate({ mutation: updateUserMutation, variables })).resolves.toMatchObject({
+          data: {
+            UpdateUser: {
+              name: 'John Doughnut',
+              location: {
+                name: null,
+                nameEN: 'Paris',
+              },
+            },
+          },
+          errors: undefined,
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-11-12T18:15:29Z" title="Tuesday, November 12th 2019, 7:15:29 pm +01:00">Nov 12, 2019</time>_
_Merged <time datetime="2019-11-12T21:39:00Z" title="Tuesday, November 12th 2019, 10:39:00 pm +01:00">Nov 12, 2019</time>_
---

A query such as `{ notifications }` would return `null` for Locations
with a missing translation, e.g. `nameRU`. This would not happen for
queries implemented by `neo4j-graphql-js` because they nullify all
missing attributes automatically.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
