### PR TITLE
build: less verbose output on build server

### DIFF
--- a/docker-compose.build-and-test.yml
+++ b/docker-compose.build-and-test.yml
@@ -2,11 +2,15 @@ version: "3.4"
 
 services:
   webapp:
+    environment:
+      - "CI=${CI}"
     image: humanconnection/nitro-web:build-and-test
     build:
       context: webapp
       target: build-and-test
   backend:
+    environment:
+      - "CI=${CI}"
     image: humanconnection/nitro-backend:build-and-test
     build:
       context: backend


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2019-11-15T16:29:38Z" title="Friday, November 15th 2019, 5:29:38 pm +01:00">Nov 15, 2019</time>_
_Merged <time datetime="2019-11-15T17:52:45Z" title="Friday, November 15th 2019, 6:52:45 pm +01:00">Nov 15, 2019</time>_
---

I'm annoyed to scroll when I'm debugging the build server logs. I think,
if you run `jest` with an environment variable `CI` set to true, it will
not try to output colorized log and also does not output which test it's
currently running.

That should lead to the desired, smaller log on Travis CI.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
