### PR TITLE
Bump styleguide to version 0.5.22

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -57,7 +57,7 @@
     ]
   },
   "dependencies": {
-    "@human-connection/styleguide": "0.5.21",
+    "@human-connection/styleguide": "0.5.22",
     "@nuxtjs/apollo": "^4.0.0-rc18",
     "@nuxtjs/axios": "~5.8.0",
     "@nuxtjs/dotenv": "~1.4.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -1129,10 +1129,10 @@
   dependencies:
     "@hapi/hoek" "6.x.x"
 
-"@human-connection/styleguide@0.5.21":
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/@human-connection/styleguide/-/styleguide-0.5.21.tgz#ef577325bef8577d2846f3b29567ca15856f2e39"
-  integrity sha512-psGiIfrDRfwsZ5UtFGDiq2uB/nLkfPsNpAv5c2RAI3QpK+YOp5c3W1MuHASij7Z9iFaxZ0qkuzXiOg+mVAZbdg==
+"@human-connection/styleguide@0.5.22":
+  version "0.5.22"
+  resolved "https://registry.yarnpkg.com/@human-connection/styleguide/-/styleguide-0.5.22.tgz#444ec98b8f8d1c438e2e99736dcffe432b302755"
+  integrity sha512-zYDhWWoDIEcUhAJPSrb2azBPxBfcr6igVtTx1Bz/FNMW2bIWfZIRv9U4LaJ9RG/GgjKNcVE+OPdB8zCcwqyQyA==
   dependencies:
     vue "^2.6.10"
 
@@ -14285,6 +14285,11 @@ serve-static@1.14.1, serve-static@^1.14.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
   integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.17.1"
 
 server-destroy@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2019-12-09T16:01:54Z" title="Monday, December 9th 2019, 5:01:54 pm +01:00">Dec 9, 2019</time>_
_Merged <time datetime="2019-12-10T08:56:36Z" title="Tuesday, December 10th 2019, 9:56:36 am +01:00">Dec 10, 2019</time>_
---

## 🍰 Pullrequest
upgrades to latest styleguide version which transpiles `svgs` with `babel-loader` – this should fix at least some of the browser issues we're facing in Edge and IE

### Issues
- relates (and hopefully solves) #2287
