### PR TITLE
fix: Cypress Neo4j authentication without Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - yarn global add wait-on
   # Install Codecov
   - yarn install
-  - cp backend/.env.template backend/.env
+  - cp cypress.env.template.json cypress.env.json
 
 before_script:
   - docker-compose -f docker-compose.yml build --parallel

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,6 +1,6 @@
 import dotenv from 'dotenv'
 import path from 'path'
-dotenv.config({ path: path.resolve(__dirname, '../../.env'), debug: true })
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
 
 const {
   MAPBOX_TOKEN,

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -1,7 +1,6 @@
 import dotenv from 'dotenv'
 import path from 'path'
-
-dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+dotenv.config({ path: path.resolve(__dirname, '../../.env'), debug: true })
 
 const {
   MAPBOX_TOKEN,

--- a/cypress.env.template.json
+++ b/cypress.env.template.json
@@ -1,0 +1,5 @@
+{
+  "NEO4J_URI": "bolt://localhost:7687",
+  "NEO4J_USERNAME": "neo4j",
+  "NEO4J_PASSWORD": "letmein"
+}

--- a/cypress/README.md
+++ b/cypress/README.md
@@ -16,6 +16,12 @@ First, you have to tell cypress how to connect to your local neo4j database
 among other things. You can copy our template configuration and change the new
 file according to your needs.
 
+Make sure you are at the root level of the project. Then:
+```bash
+# in the top level folder Human-Connection/
+$ cp cypress.env.template.json cypress.env.json
+```
+
 To start the services that are required for cypress testing, run:
 
 ```bash

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -13,8 +13,5 @@
 
 const cucumber = require('cypress-cucumber-preprocessor').default
 module.exports = on => {
-  // (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
   on('file:preprocessor', cucumber())
 }

--- a/cypress/support/factories.js
+++ b/cypress/support/factories.js
@@ -1,9 +1,13 @@
 import Factory from '../../backend/src/seed/factories'
 import { getDriver, getNeode } from '../../backend/src/bootstrap/neo4j'
-import neode from 'neode'
 
-const neo4jDriver = getDriver()
-const neodeInstance = getNeode()
+const neo4jConfigs = {
+  uri: Cypress.env('NEO4J_URI'),
+  username: Cypress.env('NEO4J_USERNAME'),
+  password: Cypress.env('NEO4J_PASSWORD')
+}
+const neo4jDriver = getDriver(neo4jConfigs)
+const neodeInstance = getNeode(neo4jConfigs)
 const factoryOptions = { neo4jDriver, neodeInstance }
 const factory = Factory(factoryOptions)
 


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-01-14T12:22:21Z" title="Tuesday, January 14th 2020, 1:22:21 pm +01:00">Jan 14, 2020</time>_
_Closed <time datetime="2020-01-20T09:01:27Z" title="Monday, January 20th 2020, 10:01:27 am +01:00">Jan 20, 2020</time>_
---

- It's a bit of a pain to need to run Docker just to run the cypress
tests, and while it would be nice to use the same .env, we have an issue
with relative paths, dotenv, and cypress playing nice together.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?

- relates #XXX
-->
- fixes #2773 
