### PR TITLE
fix(webapp): 🐛 Adjust Avatar Sizes and 'z-index'

### DIFF
--- a/webapp/components/AvatarMenu/AvatarMenu.vue
+++ b/webapp/components/AvatarMenu/AvatarMenu.vue
@@ -11,7 +11,7 @@
         "
         @click.prevent="toggleMenu"
       >
-        <user-avatar :user="user" />
+        <user-avatar :user="user" size="small" />
         <base-icon class="dropdown-arrow" name="angle-down" />
       </a>
     </template>
@@ -127,6 +127,10 @@ export default {
   display: flex;
   align-items: center;
   padding-left: $space-xx-small;
+
+  > .user-avatar {
+    margin-right: $space-xx-small;
+  }
 }
 .avatar-menu-popover {
   padding-top: $space-x-small;

--- a/webapp/components/PostCard/PostCard.vue
+++ b/webapp/components/PostCard/PostCard.vue
@@ -193,6 +193,8 @@ export default {
   /* workaround to avoid jumping layout when user-teaser is rendered */
   .user-wrapper {
     height: 36px;
+    position: relative;
+    z-index: $z-index-post-card-link;
   }
 
   .content-menu {

--- a/webapp/components/UserTeaser/UserTeaser.vue
+++ b/webapp/components/UserTeaser/UserTeaser.vue
@@ -158,8 +158,6 @@ export default {
 .user-teaser {
   display: flex;
   flex-wrap: nowrap;
-  z-index: $z-index-post-card-link;
-  position: relative;
 
   > .user-avatar {
     flex-shrink: 0;

--- a/webapp/components/UserTeaser/UserTeaser.vue
+++ b/webapp/components/UserTeaser/UserTeaser.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="user-teaser" v-if="displayAnonymous">
-    <user-avatar v-if="showAvatar" />
+    <user-avatar v-if="showAvatar" size="small" />
     <span class="info anonymous">{{ $t('profile.userAnonym') }}</span>
   </div>
   <dropdown

--- a/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
+++ b/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
@@ -6,7 +6,7 @@
       v-else
       :src="user.avatar | proxyApiUrl"
       class="image"
-      @error="event.target.style.display = 'none'"
+      @error="$event.target.style.display = 'none'"
     />
   </div>
 </template>

--- a/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
+++ b/webapp/components/_new/generic/UserAvatar/UserAvatar.vue
@@ -75,7 +75,6 @@ export default {
 
   > .image {
     position: relative;
-    z-index: 5;
     width: 100%;
     object-fit: cover;
     object-position: center;


### PR DESCRIPTION
> [<img alt="alina-beck" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/alina-beck) **Authored by [alina-beck](https://github.com/alina-beck)**
_<time datetime="2020-01-22T15:15:40Z" title="Wednesday, January 22nd 2020, 4:15:40 pm +01:00">Jan 22, 2020</time>_
_Merged <time datetime="2020-01-28T00:09:56Z" title="Tuesday, January 28th 2020, 1:09:56 am +01:00">Jan 28, 2020</time>_
---

## 🍰 Pullrequest
fixes some small issues @mattwr18, @Tirokk and I found with the new `UserAvatar` and `UserTeaser` that we had simply overlooked in the `migrate avatar PR` (#2700).
