### PR TITLE
fix(nuxt-env): Configuration issue with websockets

### DIFF
--- a/webapp/.env.template
+++ b/webapp/.env.template
@@ -2,3 +2,5 @@ MAPBOX_TOKEN="pk.eyJ1IjoiaHVtYW4tY29ubmVjdGlvbiIsImEiOiJjajl0cnBubGoweTVlM3VwZ2l
 SENTRY_DSN_WEBAPP=
 COMMIT=
 PUBLIC_REGISTRATION=false
+WEBSOCKETS_URI=ws://localhost:3000/api/graphql
+GRAPHQL_URI=http://localhost:4000/

--- a/webapp/nuxt.config.js
+++ b/webapp/nuxt.config.js
@@ -4,7 +4,13 @@ import dotenv from 'dotenv'
 dotenv.config() // we want to synchronize @nuxt-dotenv and nuxt-env
 
 const pkg = require('./package')
-export const envWhitelist = ['NODE_ENV', 'MAPBOX_TOKEN', 'PUBLIC_REGISTRATION']
+export const envWhitelist = [
+  'NODE_ENV',
+  'MAPBOX_TOKEN',
+  'PUBLIC_REGISTRATION',
+  'WEBSOCKETS_URI',
+  'GRAPHQL_URI',
+]
 const dev = process.env.NODE_ENV !== 'production'
 
 const styleguidePath = '../styleguide'

--- a/webapp/plugins/apollo-config.js
+++ b/webapp/plugins/apollo-config.js
@@ -5,11 +5,12 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
 })
 
-export default ({ app }) => {
-  const backendUrl = process.env.GRAPHQL_URI || 'http://localhost:4000'
+export default ({ req, nuxtState }) => {
+  const { env } = req || nuxtState
+  const backendUrl = env.GRAPHQL_URI || 'http://localhost:4000'
 
   return {
-    wsEndpoint: process.env.WEBSOCKETS_URI || 'ws://localhost:4000/graphql',
+    wsEndpoint: env.WEBSOCKETS_URI || 'ws://localhost:4000/graphql',
     httpEndpoint: process.server ? backendUrl : '/api',
     httpLinkOptions: {
       credentials: 'same-origin',


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2020-02-17T21:55:56Z" title="Monday, February 17th 2020, 10:55:56 pm +01:00">Feb 17, 2020</time>_
_Merged <time datetime="2020-02-17T23:25:12Z" title="Tuesday, February 18th 2020, 12:25:12 am +01:00">Feb 18, 2020</time>_
---

After some intensive debugging I found out that `req` (on the server)
and `nuxtState` (on the client) have access to the configurations
changed at runtime.

How did I debug it:
```
yarn run build
env WEBSOCKET_URI=whatever yarn run start
```
I also put a `console.log` into `plugins/apollo-client.js`.

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes #3064

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
