### PR TITLE
fix(subscriptions): Don't publish undefined

### DIFF
--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -53,7 +53,6 @@ const postAuthorOfComment = async (commentId, { context }) => {
 }
 
 const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
-  if (!(idsOfUsers && idsOfUsers.length)) return []
   await validateNotifyUsers(label, reason)
   let mentionedCypher
   switch (reason) {

--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -112,7 +112,7 @@ const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
 }
 
 const notifyUsersOfComment = async (label, commentId, postAuthorId, reason, context) => {
-  if (!(context.user.id !== postAuthorId)) return []
+  if (context.user.id === postAuthorId) return []
   await validateNotifyUsers(label, reason)
   const session = context.driver.session()
   const writeTxResultPromise = await session.writeTransaction(async transaction => {

--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -2,11 +2,21 @@ import extractMentionedUsers from './mentions/extractMentionedUsers'
 import { validateNotifyUsers } from '../validation/validationMiddleware'
 import { pubsub, NOTIFICATION_ADDED } from '../../server'
 
+const publishNotifications = async (...promises) => {
+  const notifications = await Promise.all(promises)
+  notifications
+    .flat()
+    .forEach(notificationAdded => pubsub.publish(NOTIFICATION_ADDED, { notificationAdded }))
+}
+
 const handleContentDataOfPost = async (resolve, root, args, context, resolveInfo) => {
   const idsOfUsers = extractMentionedUsers(args.content)
   const post = await resolve(root, args, context, resolveInfo)
-  if (post && idsOfUsers && idsOfUsers.length)
-    await notifyUsersOfMention('Post', post.id, idsOfUsers, 'mentioned_in_post', context)
+  if (post) {
+    await publishNotifications(
+      notifyUsersOfMention('Post', post.id, idsOfUsers, 'mentioned_in_post', context),
+    )
+  }
   return post
 }
 
@@ -16,10 +26,10 @@ const handleContentDataOfComment = async (resolve, root, args, context, resolveI
   const comment = await resolve(root, args, context, resolveInfo)
   const [postAuthor] = await postAuthorOfComment(comment.id, { context })
   idsOfUsers = idsOfUsers.filter(id => id !== postAuthor.id)
-  if (idsOfUsers && idsOfUsers.length)
-    await notifyUsersOfMention('Comment', comment.id, idsOfUsers, 'mentioned_in_comment', context)
-  if (context.user.id !== postAuthor.id)
-    await notifyUsersOfComment('Comment', comment.id, postAuthor.id, 'commented_on_post', context)
+  await publishNotifications(
+    notifyUsersOfMention('Comment', comment.id, idsOfUsers, 'mentioned_in_comment', context),
+    notifyUsersOfComment('Comment', comment.id, postAuthor.id, 'commented_on_post', context),
+  )
   return comment
 }
 
@@ -29,7 +39,7 @@ const postAuthorOfComment = async (commentId, { context }) => {
   try {
     postAuthorId = await session.readTransaction(transaction => {
       return transaction.run(
-        ` 
+        `
           MATCH (author:User)-[:WROTE]->(:Post)<-[:COMMENTS]-(:Comment { id: $commentId })
           RETURN author { .id } as authorId
         `,
@@ -43,6 +53,7 @@ const postAuthorOfComment = async (commentId, { context }) => {
 }
 
 const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
+  if (!(idsOfUsers && idsOfUsers.length)) return []
   await validateNotifyUsers(label, reason)
   let mentionedCypher
   switch (reason) {
@@ -91,8 +102,8 @@ const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
     return notificationTransactionResponse.records.map(record => record.get('notification'))
   })
   try {
-    const [notification] = await writeTxResultPromise
-    return pubsub.publish(NOTIFICATION_ADDED, { notificationAdded: notification })
+    const notifications = await writeTxResultPromise
+    return notifications
   } catch (error) {
     throw new Error(error)
   } finally {
@@ -101,6 +112,7 @@ const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
 }
 
 const notifyUsersOfComment = async (label, commentId, postAuthorId, reason, context) => {
+  if (!(context.user.id !== postAuthorId)) return []
   await validateNotifyUsers(label, reason)
   const session = context.driver.session()
   const writeTxResultPromise = await session.writeTransaction(async transaction => {
@@ -121,8 +133,8 @@ const notifyUsersOfComment = async (label, commentId, postAuthorId, reason, cont
     return notificationTransactionResponse.records.map(record => record.get('notification'))
   })
   try {
-    const [notification] = await writeTxResultPromise
-    return pubsub.publish(NOTIFICATION_ADDED, { notificationAdded: notification })
+    const notifications = await writeTxResultPromise
+    return notifications
   } finally {
     session.close()
   }

--- a/backend/src/middleware/notifications/notificationsMiddleware.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.js
@@ -53,6 +53,7 @@ const postAuthorOfComment = async (commentId, { context }) => {
 }
 
 const notifyUsersOfMention = async (label, id, idsOfUsers, reason, context) => {
+  if (!(idsOfUsers && idsOfUsers.length)) return []
   await validateNotifyUsers(label, reason)
   let mentionedCypher
   switch (reason) {

--- a/backend/src/middleware/notifications/notificationsMiddleware.spec.js
+++ b/backend/src/middleware/notifications/notificationsMiddleware.spec.js
@@ -528,7 +528,7 @@ describe('notifications', () => {
           })
           it('sends only one notification with reason commented_on_post, no notification with reason mentioned_in_comment', async () => {
             await createCommentOnPostAction()
-            const expected = expect.objectContaining({
+            const expected = {
               data: {
                 notifications: [
                   {
@@ -543,7 +543,7 @@ describe('notifications', () => {
                   },
                 ],
               },
-            })
+            }
 
             await expect(
               query({
@@ -552,7 +552,7 @@ describe('notifications', () => {
                   read: false,
                 },
               }),
-            ).resolves.toEqual(expected)
+            ).resolves.toMatchObject(expected, { errors: undefined })
           })
         })
 


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2020-02-18T14:23:39Z" title="Tuesday, February 18th 2020, 3:23:39 pm +01:00">Feb 18, 2020</time>_
_Merged <time datetime="2020-02-19T08:47:39Z" title="Wednesday, February 19th 2020, 9:47:39 am +01:00">Feb 19, 2020</time>_
---

Fix #3088

## 🍰 Pullrequest
Notifications not being created seems to be expected behaviour. But we never want to publish `{notificationAdded: undefined}`. This PR ensures this won't happen.

### Issues
- fixes #3088 

This might also be a fix for our stalled builds as it avoids JavaScript runtime errors (?)