### PR TITLE
fix(migration): Avoid unique constraint violation

### DIFF
--- a/backend/src/db/migrations/20200320200315-refactor_all_images_to_separate_type.js
+++ b/backend/src/db/migrations/20200320200315-refactor_all_images_to_separate_type.js
@@ -24,9 +24,9 @@ export async function up() {
         `
       MATCH (post:Post)
       WHERE post.image IS NOT NULL
-      CREATE (post)-[:HERO_IMAGE]->(image:Image)
+      MERGE(image:Image {url: post.image})
+      CREATE (post)-[:HERO_IMAGE]->(image)
       SET
-        image.url         = post.image,
         image.sensitive   = post.imageBlurred,
         image.aspectRatio = post.imageAspectRatio
       REMOVE
@@ -37,15 +37,15 @@ export async function up() {
         `
       MATCH (user:User)
       WHERE user.avatar IS NOT NULL
-      CREATE (user)-[:AVATAR_IMAGE]->(avatar:Image)
-      SET avatar.url = user.avatar
+      MERGE(avatar:Image {url: user.avatar})
+      CREATE (user)-[:AVATAR_IMAGE]->(avatar)
       REMOVE user.avatar
     `,
         `
       MATCH (user:User)
       WHERE user.coverImg IS NOT NULL
-      CREATE (user)-[:COVER_IMAGE]->(coverImage:Image)
-      SET coverImage.url = user.coverImg
+      MERGE(coverImage:Image {url: user.coverImg})
+      CREATE (user)-[:COVER_IMAGE]->(coverImage)
       REMOVE user.coverImg
     `,
       ].map(s => txc.run(s)),


### PR DESCRIPTION
> [<img alt="roschaefer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/roschaefer) **Authored by [roschaefer](https://github.com/roschaefer)**
_<time datetime="2020-03-20T18:57:36Z" title="Friday, March 20th 2020, 7:57:36 pm +01:00">Mar 20, 2020</time>_
_Merged <time datetime="2020-03-23T08:31:05Z" title="Monday, March 23rd 2020, 9:31:05 am +01:00">Mar 23, 2020</time>_
---

## 🍰 Pullrequest
Apparently we have posts or users which have the same `imageUrl` or `avatar`. If we create image nodes we will run into unique constraint violations when we try to create the unique index.

~When I try to `yarn run db:migrate up` on production data on my machine and in docker the migration takes way too much time.~ If you create the unique index first, it's doing fine.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] Check migration with image files (locally or on staging)
