### PR TITLE
feat: [WIP] limit notifications to 25 for menu

### DIFF
--- a/backend/src/db/factories.js
+++ b/backend/src/db/factories.js
@@ -64,7 +64,7 @@ Factory.define('basicUser')
     password: '1234',
     role: 'user',
     about: faker.lorem.paragraph,
-    termsAndConditionsAgreedVersion: '0.0.1',
+    termsAndConditionsAgreedVersion: '0.0.4',
     termsAndConditionsAgreedAt: '2019-08-01T10:47:19.212Z',
     allowEmbedIframes: false,
     showShoutsPublicly: false,

--- a/backend/src/db/seed.js
+++ b/backend/src/db/seed.js
@@ -1151,10 +1151,10 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
     )
 
     await Promise.all(
-      [...Array(45).keys()].map(() =>
+      [...Array(45).keys()].map((i) =>
         Factory.build(
           'post',
-          {},
+          { id: `p${i + 45}` },
           {
             categoryIds: ['cat1'],
             author: bobDerBaumeister,
@@ -1259,7 +1259,19 @@ const languages = ['de', 'en', 'es', 'fr', 'it', 'pt', 'pl']
         ),
       ),
     )
-
+    const notificationsCypher = `
+      MATCH (post:Post {id: $id}), (user:User {id: 'u3'})
+      CREATE (post)-[notification:NOTIFIED {reason: 'mentioned_in_post'}]->(user)
+      SET notification.read = FALSE
+      SET notification.createdAt = COALESCE(notification.createdAt, toString(datetime()))
+      SET notification.updatedAt = toString(datetime())
+      RETURN notification;
+    `
+    await Promise.all(
+      [...Array(45).keys()].map(async (i) => {
+        await neode.cypher(notificationsCypher, { id: `p${i + 45}` })
+      }),
+    )
     await Factory.build('donations')
     /* eslint-disable-next-line no-console */
     console.log('Seeded Data...')

--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -104,7 +104,6 @@ export default shield(
       mutedUsers: isAuthenticated,
       blockedUsers: isAuthenticated,
       notifications: isAuthenticated,
-      unreadNotificationsCount: isAuthenticated,
       Donations: isAuthenticated,
     },
     Mutation: {

--- a/backend/src/middleware/permissionsMiddleware.js
+++ b/backend/src/middleware/permissionsMiddleware.js
@@ -104,6 +104,7 @@ export default shield(
       mutedUsers: isAuthenticated,
       blockedUsers: isAuthenticated,
       notifications: isAuthenticated,
+      unreadNotificationsCount: isAuthenticated,
       Donations: isAuthenticated,
     },
     Mutation: {

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -94,12 +94,6 @@ export default {
       createdAt: { type: 'string', isoDate: true, default: () => new Date().toISOString() },
     },
   },
-  notifications: {
-    type: 'relationship',
-    relationship: 'NOTIFIED',
-    target: 'User',
-    direction: 'in',
-  },
   termsAndConditionsAgreedVersion: {
     type: 'string',
     allow: [null],

--- a/backend/src/schema/types/type/NOTIFIED.gql
+++ b/backend/src/schema/types/type/NOTIFIED.gql
@@ -8,6 +8,11 @@ type NOTIFIED {
   reason: NotificationReason
 }
 
+type notificationsResult {
+  notificationsCount: Int!
+  notifications: [NOTIFIED]
+}
+
 union NotificationSource = Post | Comment
 
 enum NotificationOrdering {
@@ -24,8 +29,7 @@ enum NotificationReason {
 }
 
 type Query {
-  notifications(read: Boolean, orderBy: NotificationOrdering, first: Int, offset: Int): [NOTIFIED]
-  unreadNotificationsCount: Int!
+  notifications(read: Boolean, orderBy: NotificationOrdering, first: Int, offset: Int): notificationsResult!
 }
   
 type Mutation {
@@ -33,5 +37,5 @@ type Mutation {
 }
 
 type Subscription {
-  notificationAdded(userId: ID!): NOTIFIED
+  notificationAdded(userId: ID!): notificationsResult
 }

--- a/backend/src/schema/types/type/NOTIFIED.gql
+++ b/backend/src/schema/types/type/NOTIFIED.gql
@@ -25,6 +25,7 @@ enum NotificationReason {
 
 type Query {
   notifications(read: Boolean, orderBy: NotificationOrdering, first: Int, offset: Int): [NOTIFIED]
+  unreadNotificationsCount: Int!
 }
   
 type Mutation {

--- a/webapp/components/CommentList/CommentList.vue
+++ b/webapp/components/CommentList/CommentList.vue
@@ -48,7 +48,7 @@ export default {
       return anchor === '#comments'
     },
     updateCommentList(updatedComment) {
-      this.postComments = this.postComments.map((comment) => {
+      this.post.comments = this.postComments.map((comment) => {
         return comment.id === updatedComment.id ? updatedComment : comment
       })
     },

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -69,28 +69,30 @@ export const notificationQuery = (i18n) => {
 
     query($read: Boolean, $orderBy: NotificationOrdering, $first: Int, $offset: Int) {
       notifications(read: $read, orderBy: $orderBy, first: $first, offset: $offset) {
-        id
-        read
-        reason
-        createdAt
-        updatedAt
-        from {
-          __typename
-          ... on Post {
-            ...post
-            author {
-              ...user
-            }
-          }
-          ... on Comment {
-            ...comment
-            author {
-              ...user
-            }
-            post {
+        notificationsCount
+        notifications {
+          id
+          read
+          reason
+          createdAt
+          updatedAt
+          from {
+            ... on Post {
               ...post
               author {
                 ...user
+              }
+            }
+            ... on Comment {
+              ...comment
+              author {
+                ...user
+              }
+              post {
+                ...post
+                author {
+                  ...user
+                }
               }
             }
           }
@@ -144,28 +146,31 @@ export const notificationAdded = () => {
 
     subscription notifications($userId: ID!) {
       notificationAdded(userId: $userId) {
-        id
-        read
-        reason
-        createdAt
-        updatedAt
-        from {
-          __typename
-          ... on Post {
-            ...post
-            author {
-              ...user
-            }
-          }
-          ... on Comment {
-            ...comment
-            author {
-              ...user
-            }
-            post {
+        notificationsCount
+        notifications {
+          id
+          read
+          reason
+          createdAt
+          updatedAt
+          from {
+            __typename
+            ... on Post {
               ...post
               author {
                 ...user
+              }
+            }
+            ... on Comment {
+              ...comment
+              author {
+                ...user
+              }
+              post {
+                ...post
+                author {
+                  ...user
+                }
               }
             }
           }
@@ -174,12 +179,6 @@ export const notificationAdded = () => {
     }
   `
 }
-
-export const unreadNotificationsCountQuery = gql`
-  query {
-    unreadNotificationsCount
-  }
-`
 
 export const followUserMutation = (i18n) => {
   return gql`

--- a/webapp/graphql/User.js
+++ b/webapp/graphql/User.js
@@ -174,6 +174,13 @@ export const notificationAdded = () => {
     }
   `
 }
+
+export const unreadNotificationsCountQuery = gql`
+  query {
+    unreadNotificationsCount
+  }
+`
+
 export const followUserMutation = (i18n) => {
   return gql`
     ${userFragment}

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -450,6 +450,7 @@
       "read": "Read",
       "unread": "Unread"
     },
+    "manyNotifications": "See all {unreadNotificationsCount} notifications",
     "pageLink": "All notifications",
     "post": "Post",
     "reason": {

--- a/webapp/locales/en.json
+++ b/webapp/locales/en.json
@@ -450,7 +450,7 @@
       "read": "Read",
       "unread": "Unread"
     },
-    "manyNotifications": "See all {unreadNotificationsCount} notifications",
+    "manyNotifications": "See all {notificationsCount} notifications",
     "pageLink": "All notifications",
     "post": "Post",
     "reason": {


### PR DESCRIPTION
> [<img alt="mattwr18" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/mattwr18) **Authored by [mattwr18](https://github.com/mattwr18)**
_<time datetime="2020-04-04T17:49:46Z" title="Saturday, April 4th 2020, 7:49:46 pm +02:00">Apr 4, 2020</time>_

---

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->
There are some things to pay attention to with this, like the counter updating with `markAsRead`/`susbcriptions`, but in general I think we want to move away from asking for all of a users notifications every time they log in or refresh the page.
We have the `All notifications` page for this.
### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
