### PR TITLE
fix: [WIP] 🍰 Editor List Styles [3492]

### DIFF
--- a/webapp/assets/_new/styles/tokens.scss
+++ b/webapp/assets/_new/styles/tokens.scss
@@ -191,10 +191,10 @@ $font-weight-bold: 600;
  * @presenter LineHeight
  */
 
-$line-height-large: 1.5;
-$line-height-base: 1.3;
-$line-height-small: 1.1;
-$line-height-smaller: 1.0;
+$line-height-large: 1.5rem;
+$line-height-base: 1.3rem;
+$line-height-small: 1.1rem;
+$line-height-smaller: 1.0rem;
 
 /**
  * @tokens Letter Spacing
@@ -352,3 +352,8 @@ $media-query-small: (min-width: 600px);
 $media-query-medium: (min-width: 768px);
 $media-query-large: (min-width: 1024px);
 $media-query-x-large: (min-width: 1200px);
+
+/** 
+ * @tokens Background Images
+ */
+$background-image-logo: url('/icon.png');

--- a/webapp/components/Editor/ContentViewer.story.js
+++ b/webapp/components/Editor/ContentViewer.story.js
@@ -1,0 +1,78 @@
+import { storiesOf } from '@storybook/vue'
+import { withA11y } from '@storybook/addon-a11y'
+import ContentViewer from '~/components/Editor/ContentViewer.vue'
+import helpers from '~/storybook/helpers'
+
+helpers.init()
+
+storiesOf('ContentViewer', module)
+  .addDecorator(withA11y)
+  .addDecorator((storyFn) => {
+    const ctx = storyFn()
+    return {
+      components: { ctx },
+      template: `
+        <base-card style="width: 50%; min-width: 500px; margin: 0 auto;">
+          <ctx />
+        </base-card>
+      `,
+    }
+  })
+  .addDecorator(helpers.layout)
+  .add('Basic formatting', () => ({
+    components: { ContentViewer },
+    store: helpers.store,
+    data: () => ({
+      content: `
+        <h3>Basic formatting</h3>
+        <p>
+          Here is some <em>italic</em>, <b>bold</b> and <u>underline</u> text.
+          <br/>
+          Also do we have some <a href="https://human-connection.org">inline links</a> here.
+        </p>
+        <h3>Heading 3</h3>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+        <h4>Heading 4</h4>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+        <h5>Heading 5</h5>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+
+        <h3>Unordered List</h3>
+        <ul>
+          <li><p>Also some list</p></li>
+          <li><p>with</p></li>
+          <li><p>several</p></li>
+          <li>
+            <p>points</p>
+            <ul>
+              <li>
+                <p>and indentations</p>
+                <p>as well as text parapgraphs</p>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <h3>Ordered List</h3>
+        <ol>
+          <li>
+            <p>ordered lists</p>
+            <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsu</p>
+            <ol>
+              <li>
+                <p>can have indentations</p>
+                <ol>
+                  <li>
+                <p>and text parapgraphs, too</p>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+                </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      `,
+    }),
+    template: `<content-viewer :content="content" />`,
+  }))

--- a/webapp/components/Editor/Editor.story.js
+++ b/webapp/components/Editor/Editor.story.js
@@ -79,15 +79,35 @@ storiesOf('Editor', module)
           <li><p>Also some list</p></li>
           <li><p>with</p></li>
           <li><p>several</p></li>
-          <li><p>points</p></li>
+          <li>
+            <p>points</p>
+            <ul>
+              <li>
+                <p>and indentations</p>
+                <p>as well as text parapgraphs</p>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+              </li>
+            </ul>
+          </li>
         </ul>
 
         <h3>Ordered List</h3>
         <ol>
-          <li><p>justo</p></li>
-          <li><p>dolores</p></li>
-          <li><p>et ea rebum</p></li>
-          <li><p>kasd gubergren</p></li>
+          <li>
+            <p>ordered lists</p>
+            <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsu</p>
+            <ol>
+              <li>
+                <p>can have indentations</p>
+                <ol>
+                  <li>
+                <p>and text parapgraphs, too</p>
+        <p>At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>
+                </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
         </ol>
       `,
     }),

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -327,5 +327,28 @@ li > p {
   p {
     margin: 0 0 $space-x-small;
   }
+
+  ol {
+    counter-reset: item;
+    padding-left: $space-x-small;
+
+    li {
+      display: block;
+
+      &:before {
+        content: counters(item, '.') '.';
+        counter-increment: item;
+        margin-right: $space-x-small;
+      }
+
+      > p {
+        display: inline-block;
+      }
+    }
+  }
+
+  > ol {
+    padding-left: $space-small;
+  }
 }
 </style>

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -328,7 +328,28 @@ li > p {
     margin: 0 0 $space-x-small;
   }
 
+  ul {
+    li {
+      display: block;
+
+      &:before {
+        content: '';
+        background-image: $background-image-logo;
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: $line-height-small;
+        padding: $space-none $space-x-small;
+        margin-right: $space-x-small;
+      }
+
+      > p {
+        display: inline-block;
+      }
+    }
+  }
+
   ol {
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
     counter-reset: item;
     padding-left: $space-x-small;
 
@@ -347,7 +368,8 @@ li > p {
     }
   }
 
-  > ol {
+  > ol,
+  > ul {
     padding-left: $space-small;
   }
 }

--- a/webapp/components/Editor/Editor.vue
+++ b/webapp/components/Editor/Editor.vue
@@ -329,10 +329,12 @@ li > p {
   }
 
   ul {
+    padding-left: $space-small;
+
     li {
       display: block;
 
-      &:before {
+      p:first-child:before {
         content: '';
         background-image: $background-image-logo;
         background-position: center;
@@ -342,8 +344,8 @@ li > p {
         margin-right: $space-x-small;
       }
 
-      > p {
-        display: inline-block;
+      p:not(:first-child) {
+        padding-left: $space-base;
       }
     }
   }
@@ -351,26 +353,21 @@ li > p {
   ol {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
     counter-reset: item;
-    padding-left: $space-x-small;
+    padding-left: $space-small;
 
     li {
       display: block;
 
-      &:before {
+      p:first-child:before {
         content: counters(item, '.') '.';
         counter-increment: item;
         margin-right: $space-x-small;
       }
 
-      > p {
-        display: inline-block;
+      p:not(:first-child) {
+        padding-left: $space-base;
       }
     }
-  }
-
-  > ol,
-  > ul {
-    padding-left: $space-small;
   }
 }
 </style>


### PR DESCRIPTION
> [<img alt="rbeer" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/rbeer) **Authored by [rbeer](https://github.com/rbeer)**
_<time datetime="2020-04-21T00:20:09Z" title="Tuesday, April 21st 2020, 2:20:09 am +02:00">Apr 21, 2020</time>_

---

## 🍰 Pullrequest
Adds decorators back to `<ul>`, `<ol>` Elements, inside Editor.
Using the logo as bullet is maybe a bit over the top :relaxed: 

![list_decorators](https://user-images.githubusercontent.com/3411649/79811337-e2efcc80-8375-11ea-83a1-d92b7e0df074.png)

![list_decorators_content](https://user-images.githubusercontent.com/3411649/79819413-3c61f680-838a-11ea-98dd-c99ae85f83df.png)


### Issues
- fixes #3492
