### PR TITLE
fix: css so follow button isn't blocked by adblock [2888]

### DIFF
--- a/webapp/components/FollowButton.vue
+++ b/webapp/components/FollowButton.vue
@@ -1,6 +1,6 @@
 <template>
   <base-button
-    class="follow-button"
+    class="track-button"
     :disabled="disabled || !followId"
     :loading="loading"
     :icon="icon"
@@ -85,7 +85,7 @@ export default {
 </script>
 
 <style lang="scss">
-.follow-button {
+.track-button {
   display: block;
   width: 100%;
 }


### PR DESCRIPTION
> [<img alt="nila99" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/nila99) **Authored by [nila99](https://github.com/nila99)**
_<time datetime="2020-04-21T03:56:54Z" title="Tuesday, April 21st 2020, 5:56:54 am +02:00">Apr 21, 2020</time>_

---

I change the name of the css classes that held the follow button on a user's profile so that it no longer is blocked by uBlock. 
